### PR TITLE
Add register decorator

### DIFF
--- a/vulcano/app/test_classes.py
+++ b/vulcano/app/test_classes.py
@@ -26,8 +26,9 @@ class TestVulcanoApp(unittest.TestCase):
         def test_function(what):
             return what
 
-        self.vulcano_app.register('test_function', test_function,
-                             'This is just a test function')
+        self.vulcano_app.register_command(
+            test_function, 'test_function', 'This is just a test function'
+        )
         result = self.vulcano_app.run('test_function', 'Passed!')
         self.assertEquals(result, 'Passed!')
 
@@ -38,8 +39,9 @@ class TestVulcanoApp(unittest.TestCase):
         def test_function(arg1=None, arg2=None):
             return arg1
 
-        self.vulcano_app.register('test_function', test_function,
-                             'This is just a test function')
+        self.vulcano_app.register_command(
+            test_function, 'test_function', 'This is just a test function'
+        )
         result = self.vulcano_app.run('test_function', arg2='No one',
                                       arg1='Passed!')
         self.assertEquals(result, 'Passed!')
@@ -48,6 +50,35 @@ class TestVulcanoApp(unittest.TestCase):
         """
         Vulcano app cannot register two commands with same name
         """
-        self.vulcano_app.register('foo', lambda x: None, 'Dummy function')
+        self.vulcano_app.register_command(
+            lambda x: None, 'foo', 'Dummy function'
+        )
         with self.assertRaises(NameError):
-            self.vulcano_app.register('foo', lambda x: None, 'Dummy function')
+            self.vulcano_app.register_command(
+                lambda x: None, 'foo', 'Dummy function'
+            )
+
+    def test_it_should_register_with_default(self):
+        """
+        Vulcano app should be able to register commands without having to pass
+        name and/or description
+        """
+        def test_function():
+            """ Test function documentation """
+            pass
+
+        self.vulcano_app.register_command(test_function)
+        command = self.vulcano_app.get('test_function')
+        self.assertEquals(command.name, 'test_function')
+        self.assertEquals(command.description, " Test function documentation ")
+
+    def test_register_decorator(self):
+        @self.vulcano_app.register()
+        def foo_function(arg1=0, arg2=0):
+            """ Docstring """
+            return arg1 + arg2
+
+        command = self.vulcano_app.get('foo_function')
+        self.assertEquals(command.name, 'foo_function')
+        self.assertEquals(command.description, ' Docstring ')
+        self.assertEquals(foo_function(1, 1), 2)


### PR DESCRIPTION
Add register decorator in order to be able to register easily a
command with just:
  `@vulcano_app.register(name='func_name')`