### PR TITLE
Add last command result inside the context

### DIFF
--- a/vulcano/app/classes.py
+++ b/vulcano/app/classes.py
@@ -98,7 +98,7 @@ class VulcanoApp(Singleton):
             command_name = command[0]
             arguments = " ".join(command[1:])
             args, kwargs = inline_parser(arguments)
-            self._manager.run(command_name, *args, **kwargs)
+            self._execute_command(command_name, *args, **kwargs)
 
     def _exec_from_repl(self, theme=dark_theme):
         self.do_repl = True
@@ -121,6 +121,10 @@ class VulcanoApp(Singleton):
                 command = user_input.split()[0]
                 arguments = " ".join(user_input.split()[1:])
                 args, kwargs = inline_parser(arguments)
-                self._manager.run(command, *args, **kwargs)
+                self._execute_command(command, *args, **kwargs)
             except Exception as error:
                 print("Error executing: {}. Error: {}".format(command, error))
+
+    def _execute_command(self, command_name, *args, **kwargs):
+        self.context['last_result'] = self._manager.run(command_name, *args, **kwargs)
+        return self.context['last_result']

--- a/vulcano/app/test_classes.py
+++ b/vulcano/app/test_classes.py
@@ -51,3 +51,30 @@ class TestVulcanoApp(TestCase):
 
         app.run()
         mock_execution.test_function_called.assert_called_once()
+
+    @patch("vulcano.app.classes.PromptSession")
+    @patch("vulcano.app.classes.sys")
+    def test_should_be_store_last_result_in_context_in_repl(self, sys_mock, prompt_session_mock):
+        session_instance = prompt_session_mock.return_value
+        session_instance.prompt.side_effect = ("test_function", EOFError)
+        sys_mock.argv = ["ensure_repl"]
+        app = VulcanoApp()
+
+        @app.command()
+        def test_function():
+            return "This is the last result"
+
+        app.run()
+        self.assertEqual(app.context["last_result"], "This is the last result")
+
+    @patch("vulcano.app.classes.sys")
+    def test_should_be_store_last_result_in_context_in_args(self, sys_mock):
+        sys_mock.argv = ["ensure_no_repl", "test_function"]
+        app = VulcanoApp()
+
+        @app.command()
+        def test_function():
+            return "This is the last result"
+
+        app.run()
+        self.assertEqual(app.context["last_result"], "This is the last result")


### PR DESCRIPTION
In order to be able to acces the last command result, it will be stored
by default inside the application context under the 'last_result' key.