### PR TITLE
Add support for register without parentheses

### DIFF
--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -9,11 +9,11 @@ app = VulcanoApp()
 def salute_method_here(name, title="Mr."):
     print("Hi! {} {} :) Glad to see you.".format(title, name))
 
-@app.command()
+@app.command
 def i_am(name):
     app.context['name'] = name
 
-@app.command()
+@app.command
 def whoami():
     return app.context['name']
 

--- a/vulcano/command/classes.py
+++ b/vulcano/command/classes.py
@@ -8,6 +8,7 @@ Vulcano command classes are active classes that handles with commands.
 from __future__ import print_function
 import importlib
 from inspect import getmembers, isfunction
+from functools import partial
 
 # Third-party imports
 import six
@@ -43,7 +44,7 @@ class Magma(object):
             ]
         return self._command_names
 
-    def command(self, name=None, description=None):
+    def command(self, name_or_function=None, description=None):
         """
         Register decorator used to command a command functions directly on vulcano app
 
@@ -52,7 +53,11 @@ class Magma(object):
         :return:
         """
 
-        def decorator_register(func):
+        def decorator_register(func, name=None):
+            """ Function wrapper used as decorator
+
+            As we need access to self, we cannot use wrap from functools.
+            """
             self.register_command(func, name, description)
 
             def func_wrapper(*args, **kwargs):
@@ -60,7 +65,11 @@ class Magma(object):
 
             return func_wrapper
 
-        return decorator_register
+        if callable(name_or_function):
+            function = name_or_function
+            return decorator_register(function)
+        name = name_or_function
+        return partial(decorator_register, name=name)
 
     def module(self, module):
         """

--- a/vulcano/command/test_classes.py
+++ b/vulcano/command/test_classes.py
@@ -117,6 +117,17 @@ class TestMagma(unittest.TestCase):
         self.assertEqual(command.description, " Docstring ")
         self.assertEqual(foo_function(1, 1), 2)
 
+    def test_register_decorator_without_parentheses(self):
+        @self.magma.command
+        def foo_function(arg1=0, arg2=0):
+            """ Docstring """
+            return arg1 + arg2
+
+        command = self.magma.get("foo_function")
+        self.assertEqual(command.name, "foo_function")
+        self.assertEqual(command.description, " Docstring ")
+        self.assertEqual(foo_function(1, 1), 2)
+
     def test_register_module_from_string(self):
         self.magma.module('vulcano.command.test_classes')
         self.assertListEqual(self.magma.command_names, ["test_function"])


### PR DESCRIPTION
By doing this, we're able to register with `@app.command` and with
`@app.command()`.