### PR TITLE
Fix handling of empty user input

### DIFF
--- a/vulcano/app/classes.py
+++ b/vulcano/app/classes.py
@@ -135,8 +135,11 @@ class VulcanoApp(Singleton):
                 break  # Control-D Pressed. Finish
 
             try:
-                command = user_input.split()[0]
-                arguments = " ".join(user_input.split()[1:])
+                command_list = user_input.split()
+                if not command_list:
+                    continue
+                command = command_list[0]
+                arguments = " ".join(command_list[1:])
                 try:
                     arguments = arguments.format(**self.context)
                 except KeyError:

--- a/vulcano/app/test_classes.py
+++ b/vulcano/app/test_classes.py
@@ -69,6 +69,21 @@ class TestVulcanoApp(TestCase):
 
     @patch("vulcano.app.classes.PromptSession")
     @patch("vulcano.app.classes.sys")
+    def test_does_not_throw_while_handling_empty_repl_input(
+        self, sys_mock, prompt_session_mock
+    ):
+        session_instance = prompt_session_mock.return_value
+        session_instance.prompt.side_effect = ("", EOFError)
+        sys_mock.argv = ["ensure_repl"]
+        app = VulcanoApp()
+
+        try:
+            app.run()
+        except:
+            self.fail("Exception was raised unexpectedly")
+
+    @patch("vulcano.app.classes.PromptSession")
+    @patch("vulcano.app.classes.sys")
     def test_should_be_store_last_result_in_context_in_repl(
         self, sys_mock, prompt_session_mock
     ):


### PR DESCRIPTION
This PR fixes case when user simply hits `<ENTER>` in the prompt line.