### PR TITLE
Pin prompt_toolkit requirement version to 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     install_requires=[
         "pyparsing>=2.3.1",
         "pygments",
-        "prompt_toolkit"
+        "prompt_toolkit>=2.0.1"
     ]
 )


### PR DESCRIPTION
The vulcano framework is not compatible with prompt_toolkit 1.X, as
ipython uses prompt_toolkit 1.0, seems there are some issue with the
installation, as the library was already installed.

This should fix issue #70