### PR TITLE
Enable importing VulcanoApp from vulcano.app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ In case you don't want to clone it, you can copy paste it:
 
     from __future__ import print_function
     import random
-    from vulcano.app.classes import VulcanoApp
+    from vulcano.app import VulcanoApp
     from vulcano.app.lexer import MonokaiTheme
 
 

--- a/examples/module_example.py
+++ b/examples/module_example.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from vulcano.app.classes import VulcanoApp
+from vulcano.app import VulcanoApp
 from vulcano.app.lexer import MonokaiTheme
 
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import random
-from vulcano.app.classes import VulcanoApp
+from vulcano.app import VulcanoApp
 from vulcano.app.lexer import MonokaiTheme
 
 

--- a/vulcano/app/__init__.py
+++ b/vulcano/app/__init__.py
@@ -1,0 +1,8 @@
+# -* coding: utf-8 *-
+# System imports
+# Third-party imports
+# Local imports
+from .classes import VulcanoApp
+
+
+__all__ = ['VulcanoApp']


### PR DESCRIPTION
This will help users whenever importing the application to not having to
write `classes` module (which doesn't even make sense).