### PR TITLE
Modify exit function to not sys.exit

### DIFF
--- a/vulcano/app/classes.py
+++ b/vulcano/app/classes.py
@@ -112,7 +112,7 @@ class _VulcanoApp(object):
             self._exec_from_repl(prompt=prompt, theme=theme, history_file=history_file)
 
     def _prepare_builtins(self):
-        self.manager.register_command(builtin.exit, "exit", show_if=rq_is_for_repl(self))
+        self.manager.register_command(builtin.exit(self), "exit", show_if=rq_is_for_repl(self))
         self.manager.register_command(builtin.help(self), "help")
 
     def _exec_from_args(self):

--- a/vulcano/command/builtin.py
+++ b/vulcano/command/builtin.py
@@ -35,6 +35,8 @@ def help(app):
     return real_help
 
 
-def exit():
-    """ Exits from the cli """
-    sys.exit(1)
+def exit(app):
+    def _exit():
+        """ Exits from the cli """
+        app.do_repl = False
+    return _exit

--- a/vulcano/command/builtin_test.py
+++ b/vulcano/command/builtin_test.py
@@ -39,10 +39,12 @@ class TestBuiltin(unittest.TestCase):
         help_func("Unknown command")
         print_mock.assert_called_once()
 
-    @patch('vulcano.command.builtin.sys')
-    def test_exit(self, sys_mock):
-        builtin.exit()
-        sys_mock.exit.assert_called_with(1)
+    def test_exit(self):
+        app = MagicMock()
+        app.do_repl = True
+        exit_func = builtin.exit(app)
+        exit_func()
+        self.assertFalse(app.do_repl)
 
     @patch(print_builtin)
     def test_help_without_command(self, print_mock):


### PR DESCRIPTION
In order to avoid exiting the application with exit code 1, we've
modified the exit function to stop the REPL loop and continue executing
the application as normal.