### PR TITLE
Adds ':' as supported character in strings

### DIFF
--- a/vulcano/command/parser.py
+++ b/vulcano/command/parser.py
@@ -12,7 +12,7 @@ from vulcano.exceptions import CommandParseError
 __all__ = ["inline_parser", "split_list_by_arg"]
 
 
-allowed_symbols_in_string = r"-_/#@£$€%*+~|<>?."
+allowed_symbols_in_string = r"-_/#@£$€%*+~|<>?.:"
 
 
 def _no_transform(x):

--- a/vulcano/command/parser_test.py
+++ b/vulcano/command/parser_test.py
@@ -44,3 +44,8 @@ class TestInlineParser(TestCase):
         command = "`´"
         with self.assertRaises(CommandParseError):
             inline_parser(command)
+
+    def test_should_parse_a_string_with_colon(self):
+        command = "git@github.com:dgarana/vulcano.git"
+        args, kwargs = inline_parser(command)
+        self.assertEqual(args, [command])


### PR DESCRIPTION
After trying to build a new command using git repos as argument for the command, the parser always failed as the ':' character is not allowed in the string.

This PR adds ':' to the supported characters string solving the issue.