### PR TITLE
Fix completer fails if command not found

### DIFF
--- a/vulcano/command/completer.py
+++ b/vulcano/command/completer.py
@@ -9,6 +9,7 @@ Vulcano APP command completer
 from prompt_toolkit.completion import Completer, Completion
 
 # Local imports
+from vulcano.exceptions import CommandNotFound
 
 
 class CommandCompleter(Completer):
@@ -39,7 +40,10 @@ class CommandCompleter(Completer):
     def __get_current_completions(self, text_arr):
         if len(text_arr) >= 1:
             command = text_arr[0]
-            command_obj = self.manager.get(command)
+            try:
+                command_obj = self.manager.get(command)
+            except CommandNotFound:
+                return []
             if command_obj:
                 return command_obj.args_completion
         else:

--- a/vulcano/command/completer_test.py
+++ b/vulcano/command/completer_test.py
@@ -53,3 +53,11 @@ class TestCommandCompleter(unittest.TestCase):
         results = list(self.completer.get_completions(document_mock, complete_event))
         expected_args = ["happened", "here"]
         self.assertListSameItems(expected_args, [result.text for result in results])
+
+
+    def test_it_should_not_fail_if_command_not_found(self):
+        document_mock = MagicMock()
+        document_mock.text_before_cursor = "non_existent "
+        complete_event = MagicMock()
+        results = list(self.completer.get_completions(document_mock, complete_event))
+        self.assertListEqual([], results)


### PR DESCRIPTION
Looks like a problem with the update of prompt-toolkit, most likely the
FuzzyCompleter.

It causes an error when no the command to retrieve it's completions was
not found.

This fixes #120