### PR TITLE
Make prompt string object property

### DIFF
--- a/vulcano/app/classes.py
+++ b/vulcano/app/classes.py
@@ -49,10 +49,10 @@ class VulcanoApp(object):
     """VulcanoApp"""
     __instances__ = {}
 
-    def __new__(cls, app_name='vulcano_default'):
+    def __new__(cls, app_name='vulcano_default', prompt=u'>> '):
         if app_name in cls.__instances__:
             return cls.__instances__.get(app_name)
-        new_app = _VulcanoApp(app_name)
+        new_app = _VulcanoApp(app_name, prompt)
         cls.__instances__[app_name] = new_app
         return new_app
 
@@ -62,13 +62,14 @@ class _VulcanoApp(object):
 
     It has the all the things needed to command/execute/manage commands."""
 
-    def __init__(self, app_name):
+    def __init__(self, app_name, prompt):
         self.app_name = app_name
         self.manager = Magma()  # type: Magma
         self.context = {}  # Type: dict
         self.print_result = True
         self.theme = None
         self.suggestions = None
+        self.prompt = prompt  # Type: string or func
 
     @property
     def request_is_for_args(self):
@@ -93,7 +94,7 @@ class _VulcanoApp(object):
         """
         return self.manager.module(module)
 
-    def run(self, prompt=u'>> ', theme=MonokaiTheme, print_result=True, history_file=None, suggestions=did_you_mean):
+    def run(self, theme=MonokaiTheme, print_result=True, history_file=None, suggestions=did_you_mean):
         """ Start the application
 
         It will run the application in Args or REPL mode, depending on the
@@ -103,7 +104,6 @@ class _VulcanoApp(object):
         :param bool print_result: If True, results from functions will be printed.
         """
         self.theme = theme
-        self.prompt = prompt
         self.suggestions = suggestions
         self.print_result = print_result
         self._prepare_builtins()

--- a/vulcano/app/classes.py
+++ b/vulcano/app/classes.py
@@ -103,13 +103,14 @@ class _VulcanoApp(object):
         :param bool print_result: If True, results from functions will be printed.
         """
         self.theme = theme
+        self.prompt = prompt
         self.suggestions = suggestions
         self.print_result = print_result
         self._prepare_builtins()
         if self.request_is_for_args:
             self._exec_from_args()
         else:
-            self._exec_from_repl(prompt=prompt, theme=theme, history_file=history_file)
+            self._exec_from_repl(theme=theme, history_file=history_file)
 
     def _prepare_builtins(self):
         self.manager.register_command(builtin.exit(self), "exit", show_if=rq_is_for_repl(self))
@@ -135,7 +136,7 @@ class _VulcanoApp(object):
                     if possible_command:
                         print('Did you mean: "{}"?'.format(possible_command))
 
-    def _exec_from_repl(self, prompt=u'>> ', theme=MonokaiTheme, history_file=None):
+    def _exec_from_repl(self, theme=MonokaiTheme, history_file=None):
         session_extra_options = {}
         if history_file:
             session_extra_options['history'] = FileHistory(os.path.expanduser(str(history_file)))
@@ -152,7 +153,7 @@ class _VulcanoApp(object):
         )
         while self.do_repl:
             try:
-                user_input = u"{}".format(session.prompt(prompt))
+                user_input = u"{}".format(session.prompt(self.prompt))
             except KeyboardInterrupt:
                 continue  # Control-C pressed. Try again.
             except EOFError:


### PR DESCRIPTION
This change makes it possible to dynamically alter the prompt by setting
the app.prompt property.

The use case of this, for me personally, is that I have an application
that has different environments. It is important for the user to know
when they are on testing vs. production when running certain commands.

This change should be backwards-compatible and non-breaking.